### PR TITLE
Incomplete support for VRExternal (Firefox Reality).

### DIFF
--- a/rust-webvr/Cargo.toml
+++ b/rust-webvr/Cargo.toml
@@ -19,7 +19,8 @@ exclude = [
 build = "build.rs"
 
 [features]
-default = ["openvr", "mock"]
+default = ["vrexternal", "openvr", "mock"]
+vrexternal = []
 openvr = ["libloading"]
 mock = []
 googlevr = ["gvr-sys"]
@@ -31,6 +32,8 @@ log  = "0.4"
 libloading = { version = "0.5", optional = true, default-features = false }
 gvr-sys = { version = "0.7", optional = true }
 ovr-mobile-sys = { version = "0.4", optional = true }
+libc = "0.2"
 
 [build-dependencies]
 gl_generator = "0.10"
+bindgen = "0.46"

--- a/rust-webvr/src/api/mod.rs
+++ b/rust-webvr/src/api/mod.rs
@@ -1,3 +1,8 @@
+#[cfg(feature = "vrexternal")]
+mod vrexternal;
+#[cfg(feature = "vrexternal")]
+pub use self::vrexternal::{VRExternalServiceCreator, VRExternalShmemPtr};
+
 #[cfg(feature = "mock")]
 mod mock;
 #[cfg(feature = "mock")]

--- a/rust-webvr/src/api/vrexternal/cpp/moz_external_vr.h
+++ b/rust-webvr/src/api/vrexternal/cpp/moz_external_vr.h
@@ -1,0 +1,423 @@
+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set ts=8 sts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef GFX_VR_EXTERNAL_API_H
+#define GFX_VR_EXTERNAL_API_H
+
+#define GFX_VR_EIGHTCC(c1, c2, c3, c4, c5, c6, c7, c8)                  \
+  ((uint64_t)(c1) << 56 | (uint64_t)(c2) << 48 | (uint64_t)(c3) << 40 | \
+   (uint64_t)(c4) << 32 | (uint64_t)(c5) << 24 | (uint64_t)(c6) << 16 | \
+   (uint64_t)(c7) << 8 | (uint64_t)(c8))
+
+#include <stddef.h>
+#include <stdint.h>
+#include <type_traits>
+
+#ifdef MOZILLA_INTERNAL_API
+#include "mozilla/TypedEnumBits.h"
+#include "mozilla/gfx/2D.h"
+#endif  // MOZILLA_INTERNAL_API
+
+#if defined(__ANDROID__)
+#include <pthread.h>
+#endif  // defined(__ANDROID__)
+
+namespace mozilla {
+#ifdef MOZILLA_INTERNAL_API
+namespace dom {
+enum class GamepadHand : uint8_t;
+enum class GamepadCapabilityFlags : uint16_t;
+}  // namespace dom
+#endif  //  MOZILLA_INTERNAL_API
+namespace gfx {
+
+static const int32_t kVRExternalVersion = 5;
+
+// We assign VR presentations to groups with a bitmask.
+// Currently, we will only display either content or chrome.
+// Later, we will have more groups to support VR home spaces and
+// multitasking environments.
+// These values are not exposed to regular content and only affect
+// chrome-only API's.  They may be changed at any time.
+static const uint32_t kVRGroupNone = 0;
+static const uint32_t kVRGroupContent = 1 << 0;
+static const uint32_t kVRGroupChrome = 1 << 1;
+static const uint32_t kVRGroupAll = 0xffffffff;
+
+static const int kVRDisplayNameMaxLen = 256;
+static const int kVRControllerNameMaxLen = 256;
+static const int kVRControllerMaxCount = 16;
+static const int kVRControllerMaxButtons = 64;
+static const int kVRControllerMaxAxis = 16;
+static const int kVRLayerMaxCount = 8;
+static const int kVRHapticsMaxCount = 32;
+
+#if defined(__ANDROID__)
+typedef uint64_t VRLayerTextureHandle;
+#elif defined(XP_MACOSX)
+typedef uint32_t VRLayerTextureHandle;
+#else
+typedef void* VRLayerTextureHandle;
+#endif
+
+struct Point3D_POD {
+  float x;
+  float y;
+  float z;
+};
+
+struct IntSize_POD {
+  int32_t width;
+  int32_t height;
+};
+
+struct FloatSize_POD {
+  float width;
+  float height;
+};
+
+#ifndef MOZILLA_INTERNAL_API
+
+enum class ControllerHand : uint8_t { _empty, Left, Right, EndGuard_ };
+
+enum class ControllerCapabilityFlags : uint16_t {
+  Cap_None = 0,
+  /**
+   * Cap_Position is set if the Gamepad is capable of tracking its position.
+   */
+  Cap_Position = 1 << 1,
+  /**
+   * Cap_Orientation is set if the Gamepad is capable of tracking its
+   * orientation.
+   */
+  Cap_Orientation = 1 << 2,
+  /**
+   * Cap_AngularAcceleration is set if the Gamepad is capable of tracking its
+   * angular acceleration.
+   */
+  Cap_AngularAcceleration = 1 << 3,
+  /**
+   * Cap_LinearAcceleration is set if the Gamepad is capable of tracking its
+   * linear acceleration.
+   */
+  Cap_LinearAcceleration = 1 << 4,
+  /**
+   * Cap_All used for validity checking during IPC serialization
+   */
+  Cap_All = (1 << 5) - 1
+};
+
+#endif  // ifndef MOZILLA_INTERNAL_API
+
+enum class VRDisplayCapabilityFlags : uint16_t {
+  Cap_None = 0,
+  /**
+   * Cap_Position is set if the VRDisplay is capable of tracking its position.
+   */
+  Cap_Position = 1 << 1,
+  /**
+   * Cap_Orientation is set if the VRDisplay is capable of tracking its
+   * orientation.
+   */
+  Cap_Orientation = 1 << 2,
+  /**
+   * Cap_Present is set if the VRDisplay is capable of presenting content to an
+   * HMD or similar device.  Can be used to indicate "magic window" devices that
+   * are capable of 6DoF tracking but for which requestPresent is not
+   * meaningful. If false then calls to requestPresent should always fail, and
+   * getEyeParameters should return null.
+   */
+  Cap_Present = 1 << 3,
+  /**
+   * Cap_External is set if the VRDisplay is separate from the device's
+   * primary display. If presenting VR content will obscure
+   * other content on the device, this should be un-set. When
+   * un-set, the application should not attempt to mirror VR content
+   * or update non-VR UI because that content will not be visible.
+   */
+  Cap_External = 1 << 4,
+  /**
+   * Cap_AngularAcceleration is set if the VRDisplay is capable of tracking its
+   * angular acceleration.
+   */
+  Cap_AngularAcceleration = 1 << 5,
+  /**
+   * Cap_LinearAcceleration is set if the VRDisplay is capable of tracking its
+   * linear acceleration.
+   */
+  Cap_LinearAcceleration = 1 << 6,
+  /**
+   * Cap_StageParameters is set if the VRDisplay is capable of room scale VR
+   * and can report the StageParameters to describe the space.
+   */
+  Cap_StageParameters = 1 << 7,
+  /**
+   * Cap_MountDetection is set if the VRDisplay is capable of sensing when the
+   * user is wearing the device.
+   */
+  Cap_MountDetection = 1 << 8,
+  /**
+   * Cap_All used for validity checking during IPC serialization
+   */
+  Cap_All = (1 << 9) - 1
+};
+
+#ifdef MOZILLA_INTERNAL_API
+MOZ_MAKE_ENUM_CLASS_BITWISE_OPERATORS(VRDisplayCapabilityFlags)
+#endif  // MOZILLA_INTERNAL_API
+
+struct VRPose {
+  float orientation[4];
+  float position[3];
+  float angularVelocity[3];
+  float angularAcceleration[3];
+  float linearVelocity[3];
+  float linearAcceleration[3];
+};
+
+struct VRHMDSensorState {
+  uint64_t inputFrameID;
+  double timestamp;
+  VRDisplayCapabilityFlags flags;
+
+  // These members will only change with inputFrameID:
+  VRPose pose;
+  float leftViewMatrix[16];
+  float rightViewMatrix[16];
+
+#ifdef MOZILLA_INTERNAL_API
+
+  void Clear() { memset(this, 0, sizeof(VRHMDSensorState)); }
+
+  bool operator==(const VRHMDSensorState& other) const {
+    return inputFrameID == other.inputFrameID && timestamp == other.timestamp;
+  }
+
+  bool operator!=(const VRHMDSensorState& other) const {
+    return !(*this == other);
+  }
+
+  void CalcViewMatrices(const gfx::Matrix4x4* aHeadToEyeTransforms);
+
+#endif  // MOZILLA_INTERNAL_API
+};
+
+struct VRFieldOfView {
+  double upDegrees;
+  double rightDegrees;
+  double downDegrees;
+  double leftDegrees;
+
+#ifdef MOZILLA_INTERNAL_API
+
+  VRFieldOfView() = default;
+  VRFieldOfView(double up, double right, double down, double left)
+      : upDegrees(up),
+        rightDegrees(right),
+        downDegrees(down),
+        leftDegrees(left) {}
+
+  void SetFromTanRadians(double up, double right, double down, double left) {
+    upDegrees = atan(up) * 180.0 / M_PI;
+    rightDegrees = atan(right) * 180.0 / M_PI;
+    downDegrees = atan(down) * 180.0 / M_PI;
+    leftDegrees = atan(left) * 180.0 / M_PI;
+  }
+
+  bool operator==(const VRFieldOfView& other) const {
+    return other.upDegrees == upDegrees && other.downDegrees == downDegrees &&
+           other.rightDegrees == rightDegrees &&
+           other.leftDegrees == leftDegrees;
+  }
+
+  bool operator!=(const VRFieldOfView& other) const {
+    return !(*this == other);
+  }
+
+  bool IsZero() const {
+    return upDegrees == 0.0 || rightDegrees == 0.0 || downDegrees == 0.0 ||
+           leftDegrees == 0.0;
+  }
+
+  Matrix4x4 ConstructProjectionMatrix(float zNear, float zFar,
+                                      bool rightHanded) const;
+
+#endif  // MOZILLA_INTERNAL_API
+};
+
+struct VRDisplayState {
+  enum Eye { Eye_Left, Eye_Right, NumEyes };
+
+  // When true, indicates that the VR service has shut down
+  bool shutdown;
+  // Minimum number of milliseconds to wait before attempting
+  // to start the VR service again
+  uint32_t mMinRestartInterval;
+  char mDisplayName[kVRDisplayNameMaxLen];
+  // eight byte character code identifier
+  // LSB first, so "ABCDEFGH" -> ('H'<<56) + ('G'<<48) + ('F'<<40) +
+  //                             ('E'<<32) + ('D'<<24) + ('C'<<16) +
+  //                             ('B'<<8) + 'A').
+  uint64_t mEightCC;
+  VRDisplayCapabilityFlags mCapabilityFlags;
+  VRFieldOfView mEyeFOV[VRDisplayState::NumEyes];
+  Point3D_POD mEyeTranslation[VRDisplayState::NumEyes];
+  IntSize_POD mEyeResolution;
+  bool mSuppressFrames;
+  bool mIsConnected;
+  bool mIsMounted;
+  FloatSize_POD mStageSize;
+  // We can't use a Matrix4x4 here unless we ensure it's a POD type
+  float mSittingToStandingTransform[16];
+  uint64_t mLastSubmittedFrameId;
+  bool mLastSubmittedFrameSuccessful;
+  uint32_t mPresentingGeneration;
+  // Telemetry
+  bool mReportsDroppedFrames;
+  uint64_t mDroppedFrameCount;
+};
+
+struct VRControllerState {
+  char controllerName[kVRControllerNameMaxLen];
+#ifdef MOZILLA_INTERNAL_API
+  dom::GamepadHand hand;
+#else
+  ControllerHand hand;
+#endif
+  uint32_t numButtons;
+  uint32_t numAxes;
+  uint32_t numHaptics;
+  // The current button pressed bit of button mask.
+  uint64_t buttonPressed;
+  // The current button touched bit of button mask.
+  uint64_t buttonTouched;
+  float triggerValue[kVRControllerMaxButtons];
+  float axisValue[kVRControllerMaxAxis];
+
+#ifdef MOZILLA_INTERNAL_API
+  dom::GamepadCapabilityFlags flags;
+#else
+  ControllerCapabilityFlags flags;
+#endif
+  VRPose pose;
+  bool isPositionValid;
+  bool isOrientationValid;
+};
+
+struct VRLayerEyeRect {
+  float x;
+  float y;
+  float width;
+  float height;
+};
+
+enum class VRLayerType : uint16_t {
+  LayerType_None = 0,
+  LayerType_2D_Content = 1,
+  LayerType_Stereo_Immersive = 2
+};
+
+enum class VRLayerTextureType : uint16_t {
+  LayerTextureType_None = 0,
+  LayerTextureType_D3D10SurfaceDescriptor = 1,
+  LayerTextureType_MacIOSurface = 2,
+  LayerTextureType_GeckoSurfaceTexture = 3
+};
+
+struct VRLayer_2D_Content {
+  VRLayerTextureHandle mTextureHandle;
+  VRLayerTextureType mTextureType;
+  uint64_t mFrameId;
+};
+
+struct VRLayer_Stereo_Immersive {
+  VRLayerTextureHandle mTextureHandle;
+  VRLayerTextureType mTextureType;
+  uint64_t mFrameId;
+  uint64_t mInputFrameId;
+  VRLayerEyeRect mLeftEyeRect;
+  VRLayerEyeRect mRightEyeRect;
+};
+
+struct VRLayerState {
+  VRLayerType type;
+  union {
+    VRLayer_2D_Content layer_2d_content;
+    VRLayer_Stereo_Immersive layer_stereo_immersive;
+  };
+};
+
+struct VRHapticState {
+  // Reference frame for timing.
+  // When 0, this does not represent an active haptic pulse.
+  uint64_t inputFrameID;
+  // Index within VRSystemState.controllerState identifying the controller
+  // to emit the haptic pulse
+  uint32_t controllerIndex;
+  // 0-based index indicating which haptic actuator within the controller
+  uint32_t hapticIndex;
+  // Start time of the haptic feedback pulse, relative to the start of
+  // inputFrameID, in seconds
+  float pulseStart;
+  // Duration of the haptic feedback pulse, in seconds
+  float pulseDuration;
+  // Intensity of the haptic feedback pulse, from 0.0f to 1.0f
+  float pulseIntensity;
+};
+
+struct VRBrowserState {
+#if defined(__ANDROID__)
+  bool shutdown;
+#endif  // defined(__ANDROID__)
+  bool presentationActive;
+  bool navigationTransitionActive;
+  VRLayerState layerState[kVRLayerMaxCount];
+  VRHapticState hapticState[kVRHapticsMaxCount];
+};
+
+struct VRSystemState {
+  bool enumerationCompleted;
+  VRDisplayState displayState;
+  VRHMDSensorState sensorState;
+  VRControllerState controllerState[kVRControllerMaxCount];
+};
+
+struct VRExternalShmem {
+  int32_t version;
+  int32_t size;
+#if defined(__ANDROID__)
+  pthread_mutex_t systemMutex;
+  pthread_mutex_t geckoMutex;
+  pthread_mutex_t servoMutex;
+  pthread_cond_t systemCond;
+  pthread_cond_t geckoCond;
+  pthread_cond_t servoCond;
+#else
+  int64_t generationA;
+#endif  // defined(__ANDROID__)
+  VRSystemState state;
+#if !defined(__ANDROID__)
+  int64_t generationB;
+  int64_t geckoGenerationA;
+  int64_t servoGenerationA;
+#endif  // !defined(__ANDROID__)
+  VRBrowserState geckoState;
+  VRBrowserState servoState;
+#if !defined(__ANDROID__)
+  int64_t geckoGenerationB;
+  int64_t servoGenerationB;
+#endif  // !defined(__ANDROID__)
+};
+
+// As we are memcpy'ing VRExternalShmem and its members around, it must be a POD
+// type
+static_assert(std::is_pod<VRExternalShmem>::value,
+              "VRExternalShmem must be a POD type.");
+
+}  // namespace gfx
+}  // namespace mozilla
+
+#endif /* GFX_VR_EXTERNAL_API_H */

--- a/rust-webvr/src/api/vrexternal/display.rs
+++ b/rust-webvr/src/api/vrexternal/display.rs
@@ -1,0 +1,268 @@
+use super::{mozgfx, VRExternalShmemPtr};
+use rust_webvr_api::utils;
+use std::cell::RefCell;
+use std::mem;
+use std::sync::Arc;
+use {
+    VRDisplay, VRDisplayData, VRDisplayEvent, VRFrameData, VRFramebuffer,
+    VRFramebufferAttributes, VRLayer, VRViewport,
+};
+
+pub type VRExternalDisplayPtr = Arc<RefCell<VRExternalDisplay>>;
+
+pub struct VRExternalDisplay {
+    system_state: mozgfx::VRSystemState,
+    browser_state: mozgfx::VRBrowserState,
+    rendered_layer: Option<VRLayer>,
+    shmem: VRExternalShmemPtr,
+    display_id: u32,
+    attributes: VRFramebufferAttributes,
+    presenting: bool,
+    events: Vec<VRDisplayEvent>,
+}
+
+impl VRExternalDisplay {
+    pub fn new(shmem: VRExternalShmemPtr) -> VRExternalDisplayPtr {
+        let system_state = shmem.as_mut().pull_system(&|_| true);
+        let browser_state = shmem.as_mut().pull_browser();
+        Arc::new(RefCell::new(VRExternalDisplay {
+            system_state,
+            browser_state,
+            rendered_layer: None,
+            shmem,
+            display_id: utils::new_id(),
+            attributes: Default::default(),
+            presenting: false,
+            events: Vec::new(),
+        }))
+    }
+
+    pub fn poll_events(&mut self) -> Vec<VRDisplayEvent> {
+        mem::replace(&mut self.events, Vec::new())
+    }
+}
+
+impl VRExternalDisplay {
+    fn push_browser(&mut self) {
+        self.shmem.as_mut().push_browser(self.browser_state.clone());
+    }
+}
+
+impl VRDisplay for VRExternalDisplay {
+    fn id(&self) -> u32 {
+        self.display_id
+    }
+
+    fn data(&self) -> VRDisplayData {
+        let mut data = VRDisplayData::default();
+
+        let state: &mozgfx::VRDisplayState = &self.system_state.displayState;
+        data.display_name = state.mDisplayName.iter().map(|x| *x as char).collect();
+        data.display_id = self.display_id;
+        data.connected = state.mIsConnected;
+
+        let flags = state.mCapabilityFlags;
+        data.capabilities.has_position =
+            (flags & mozgfx::VRDisplayCapabilityFlags_Cap_Position) != 0;
+        data.capabilities.can_present = (flags & mozgfx::VRDisplayCapabilityFlags_Cap_Present) != 0;
+        data.capabilities.has_orientation =
+            (flags & mozgfx::VRDisplayCapabilityFlags_Cap_Orientation) != 0;
+        data.capabilities.has_external_display =
+            (flags & mozgfx::VRDisplayCapabilityFlags_Cap_External) != 0;
+
+        data.stage_parameters = None;
+
+        data.left_eye_parameters.offset = [
+            state.mEyeTranslation[0].x,
+            state.mEyeTranslation[0].y,
+            state.mEyeTranslation[0].z,
+        ];
+
+        data.left_eye_parameters.render_width = state.mEyeResolution.width as u32;
+        data.left_eye_parameters.render_height = state.mEyeResolution.height as u32;
+
+        data.right_eye_parameters.offset = [
+            state.mEyeTranslation[1].x,
+            state.mEyeTranslation[1].y,
+            state.mEyeTranslation[1].z,
+        ];
+
+        data.right_eye_parameters.render_width = state.mEyeResolution.width as u32;
+        data.right_eye_parameters.render_height = state.mEyeResolution.height as u32;
+
+        let l_fov = state.mEyeFOV[mozgfx::VRDisplayState_Eye_Eye_Left as usize];
+        let r_fov = state.mEyeFOV[mozgfx::VRDisplayState_Eye_Eye_Right as usize];
+
+        data.left_eye_parameters.field_of_view.up_degrees = l_fov.upDegrees;
+        data.left_eye_parameters.field_of_view.right_degrees = l_fov.rightDegrees;
+        data.left_eye_parameters.field_of_view.down_degrees = l_fov.downDegrees;
+        data.left_eye_parameters.field_of_view.left_degrees = l_fov.leftDegrees;
+
+        data.right_eye_parameters.field_of_view.up_degrees = r_fov.upDegrees;
+        data.right_eye_parameters.field_of_view.right_degrees = r_fov.rightDegrees;
+        data.right_eye_parameters.field_of_view.down_degrees = r_fov.downDegrees;
+        data.right_eye_parameters.field_of_view.left_degrees = r_fov.leftDegrees;
+
+        data
+    }
+
+    fn inmediate_frame_data(&self, near_z: f64, far_z: f64) -> VRFrameData {
+        let sys = &self.system_state;
+
+        let mut data = VRFrameData::default();
+
+        data.pose.position = Some(sys.sensorState.pose.position);
+        data.pose.orientation = Some(sys.sensorState.pose.orientation);
+        data.left_view_matrix = sys.sensorState.leftViewMatrix;
+        data.right_view_matrix = sys.sensorState.rightViewMatrix;
+
+        let right_handed = sys.controllerState[0].hand == mozgfx::ControllerHand_Right;
+
+        let proj = |fov: mozgfx::VRFieldOfView| -> [f32; 16] {
+            use std::f64::consts::PI;
+
+            let up_tan = (fov.upDegrees * PI / 180.0).tan();
+            let down_tan = (fov.downDegrees * PI / 180.0).tan();
+            let left_tan = (fov.leftDegrees * PI / 180.0).tan();
+            let right_tan = (fov.rightDegrees * PI / 180.0).tan();
+            let handedness_scale = if right_handed { -1.0 } else { 1.0 };
+            let pxscale = 2.0 / (left_tan + right_tan);
+            let pxoffset = (left_tan - right_tan) * pxscale * 0.5;
+            let pyscale = 2.0 / (up_tan + down_tan);
+            let pyoffset = (up_tan - down_tan) * pyscale * 0.5;
+            let mut m = [0.0f32; 16];
+            m[0 * 4 + 0] = pxscale as f32;
+            m[1 * 4 + 1] = pyscale as f32;
+            m[2 * 4 + 0] = (pxoffset * handedness_scale) as f32;
+            m[2 * 4 + 1] = (-pyoffset * handedness_scale) as f32;
+            m[2 * 4 + 2] = (far_z / (near_z - far_z) * -handedness_scale) as f32;
+            m[2 * 4 + 3] = handedness_scale as f32;
+            m[3 * 4 + 2] = ((far_z * near_z) / (near_z - far_z)) as f32;
+            m
+        };
+
+        let left_fov =
+            sys.displayState.mEyeFOV[mozgfx::VRDisplayState_Eye_Eye_Left as usize];
+        let right_fov =
+            sys.displayState.mEyeFOV[mozgfx::VRDisplayState_Eye_Eye_Right as usize];
+
+        data.left_projection_matrix = proj(left_fov);
+        data.right_projection_matrix = proj(right_fov);
+
+        data.timestamp = sys.sensorState.timestamp;
+
+        data
+    }
+
+    fn synced_frame_data(&self, near_z: f64, far_z: f64) -> VRFrameData {
+        self.inmediate_frame_data(near_z, far_z)
+    }
+
+    fn reset_pose(&mut self) {
+    }
+
+    fn sync_poses(&mut self) {
+        if !self.presenting {
+            self.start_present(None);
+        }
+
+        let last_frame_id = self.system_state.displayState.mLastSubmittedFrameId;
+        let last_pres_gen = self.system_state.displayState.mPresentingGeneration;
+        let sys = self.shmem.as_mut().pull_system(&|sys| {
+            sys.displayState.mLastSubmittedFrameId >= last_frame_id ||
+                sys.displayState.mSuppressFrames ||
+                !sys.displayState.mIsConnected
+        });
+        if sys.displayState.mPresentingGeneration != last_pres_gen {
+            self.events.push(VRDisplayEvent::Exit(0));
+        } else {
+            self.system_state = sys;
+        }
+    }
+
+    fn bind_framebuffer(&mut self, _index: u32) {
+    }
+
+    fn get_framebuffers(&self) -> Vec<VRFramebuffer> {
+        let rendered_layer = self.rendered_layer.as_ref().unwrap();
+        let l = rendered_layer.left_bounds;
+        let r = rendered_layer.right_bounds;
+        vec![
+            VRFramebuffer {
+                eye_index: 0,
+                attributes: self.attributes,
+                viewport: VRViewport::new(l[0] as i32, l[1] as i32, l[2] as i32, l[3] as i32),
+            },
+            VRFramebuffer {
+                eye_index: 1,
+                attributes: self.attributes,
+                viewport: VRViewport::new(r[0] as i32, r[1] as i32, r[2] as i32, r[3] as i32),
+            },
+        ]
+    }
+
+    fn render_layer(&mut self, layer: &VRLayer) {
+        self.rendered_layer = Some(layer.clone());
+    }
+
+    fn submit_frame(&mut self) {
+        let layer_stereo_immersive = {
+            let rendered_layer = self.rendered_layer.as_ref().unwrap();
+            mozgfx::VRLayer_Stereo_Immersive {
+                mTextureHandle: rendered_layer.texture_id as u64,
+                mTextureType: mozgfx::VRLayerTextureType_LayerTextureType_GeckoSurfaceTexture,
+                mFrameId: self.system_state.sensorState.inputFrameID,
+                mLeftEyeRect: mozgfx::VRLayerEyeRect {
+                    x: rendered_layer.left_bounds[0],
+                    y: rendered_layer.left_bounds[1],
+                    width: rendered_layer.left_bounds[2],
+                    height: rendered_layer.left_bounds[3],
+                },
+                mRightEyeRect: mozgfx::VRLayerEyeRect {
+                    x: rendered_layer.right_bounds[0],
+                    y: rendered_layer.right_bounds[1],
+                    width: rendered_layer.right_bounds[2],
+                    height: rendered_layer.right_bounds[3],
+                },
+                __bindgen_padding_0: 0,
+                mInputFrameId: 0,
+            }
+        };
+
+        let layer = mozgfx::VRLayerState {
+            type_: mozgfx::VRLayerType_LayerType_Stereo_Immersive,
+            __bindgen_padding_0: 0,
+            __bindgen_anon_1: mozgfx::VRLayerState__bindgen_ty_1 {
+                layer_stereo_immersive,
+            },
+        };
+
+        self.browser_state.layerState[0] = layer;
+        self.push_browser();
+    }
+
+    fn start_present(&mut self, attributes: Option<VRFramebufferAttributes>) {
+        if self.presenting {
+            return;
+        }
+        self.presenting = true;
+        if let Some(attributes) = attributes {
+            self.attributes = attributes;
+        }
+        self.browser_state.layerState[0].type_ = mozgfx::VRLayerType_LayerType_Stereo_Immersive;
+        let count = self.browser_state.layerState.len();
+        for i in 1..count {
+            self.browser_state.layerState[i].type_ = mozgfx::VRLayerType_LayerType_None;
+        }
+        self.browser_state.presentationActive = true;
+        self.push_browser();
+    }
+
+    fn stop_present(&mut self) {
+        if !self.presenting {
+            return;
+        }
+        self.browser_state.presentationActive = false;
+        self.push_browser();
+    }
+}

--- a/rust-webvr/src/api/vrexternal/mod.rs
+++ b/rust-webvr/src/api/vrexternal/mod.rs
@@ -1,0 +1,36 @@
+mod display;
+mod mozgfx;
+mod service;
+
+use std::os::raw::c_void;
+use {VRService, VRServiceCreator};
+
+#[derive(Clone)]
+pub struct VRExternalShmemPtr(*mut mozgfx::VRExternalShmem);
+
+unsafe impl Send for VRExternalShmemPtr {}
+unsafe impl Sync for VRExternalShmemPtr {}
+
+impl VRExternalShmemPtr {
+    fn as_mut(&self) -> &mut mozgfx::VRExternalShmem {
+        unsafe { &mut *(self.0) }
+    }
+
+    pub fn new(raw: *mut c_void) -> VRExternalShmemPtr {
+        VRExternalShmemPtr(raw as *mut mozgfx::VRExternalShmem)
+    }
+}
+
+pub struct VRExternalServiceCreator(VRExternalShmemPtr);
+
+impl VRExternalServiceCreator {
+    pub fn new(ptr: VRExternalShmemPtr) -> Box<VRServiceCreator> {
+        Box::new(VRExternalServiceCreator(ptr))
+    }
+}
+
+impl VRServiceCreator for VRExternalServiceCreator {
+    fn new_service(&self) -> Box<VRService> {
+        Box::new(service::VRExternalService::new(self.0.clone()))
+    }
+}

--- a/rust-webvr/src/api/vrexternal/mozgfx.rs
+++ b/rust-webvr/src/api/vrexternal/mozgfx.rs
@@ -1,0 +1,65 @@
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(dead_code)]
+
+use libc;
+
+include!(concat!(env!("OUT_DIR"), "/moz_external_vr.rs"));
+
+pub type PthreadResult = Result<(), i32>;
+
+impl VRExternalShmem {
+    pub fn pull_system(&mut self, exit_cond: &Fn(&VRSystemState) -> bool) -> VRSystemState {
+        self.systemMutex.lock().expect("systemMutex lock error");
+        loop {
+            if exit_cond(&self.state) {
+                break;
+            }
+            self.systemCond.wait(&mut self.systemMutex).expect("systemCond wait error");
+        }
+        let state = self.state.clone();
+        self.systemMutex.unlock().expect("systemMutex unlock error");
+        state
+    }
+    pub fn pull_browser(&mut self) -> VRBrowserState {
+        self.servoMutex.lock().expect("servoMutex lock error");
+        let state = self.servoState.clone();
+        self.servoMutex.unlock().expect("servoMutex unlock error");
+        state
+    }
+    pub fn push_browser(&mut self, state: VRBrowserState) {
+        self.servoMutex.lock().expect("servoMutex lock error");
+        self.servoState = state;
+        self.servoCond.signal().expect("servoCond signal error");
+        self.servoMutex.unlock().expect("servoMutex unlock error");
+    }
+}
+
+impl pthread_mutex_t {
+    fn as_libc(&mut self) -> *mut libc::pthread_mutex_t {
+        self as *mut _ as *mut libc::pthread_mutex_t
+    }
+    pub fn lock(&mut self) -> PthreadResult {
+        let r = unsafe { libc::pthread_mutex_lock(self.as_libc()) };
+        if r == 0 { Ok(()) } else { Err(r) }
+    }
+    pub fn unlock(&mut self) -> PthreadResult {
+        let r = unsafe { libc::pthread_mutex_unlock(self.as_libc()) };
+        if r == 0 { Ok(()) } else { Err(r) }
+    }
+}
+
+impl pthread_cond_t {
+    fn as_libc(&mut self) -> *mut libc::pthread_cond_t {
+        self as *mut _ as *mut libc::pthread_cond_t
+    }
+    pub fn wait(&mut self, mutex: &mut pthread_mutex_t) -> PthreadResult {
+        let r = unsafe { libc::pthread_cond_wait(self.as_libc(), mutex.as_libc()) };
+        if r == 0 { Ok(()) } else { Err(r) }
+    }
+    pub fn signal(&mut self) -> PthreadResult {
+        let r = unsafe { libc::pthread_cond_signal(self.as_libc()) };
+        if r == 0 { Ok(()) } else { Err(r) }
+    }
+}

--- a/rust-webvr/src/api/vrexternal/service.rs
+++ b/rust-webvr/src/api/vrexternal/service.rs
@@ -1,0 +1,56 @@
+use super::display::{VRExternalDisplay, VRExternalDisplayPtr};
+use super::VRExternalShmemPtr;
+use {VRDisplayPtr, VREvent, VRGamepadPtr, VRService};
+
+pub struct VRExternalService {
+    shmem: VRExternalShmemPtr,
+    display: Option<VRExternalDisplayPtr>,
+}
+
+unsafe impl Send for VRExternalService {}
+
+impl VRService for VRExternalService {
+    fn initialize(&mut self) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn fetch_displays(&mut self) -> Result<Vec<VRDisplayPtr>, String> {
+        if self.display.is_none() {
+            // Block until enumerationCompleted is true.
+            self.shmem.as_mut().pull_system(&|state| state.enumerationCompleted);
+            let display = VRExternalDisplay::new(self.shmem.clone());
+            self.display = Some(display);
+        }
+        Ok(vec![self.display.as_ref().unwrap().clone()])
+    }
+
+    fn fetch_gamepads(&mut self) -> Result<Vec<VRGamepadPtr>, String> {
+        Ok(Vec::new())
+    }
+
+    fn is_available(&self) -> bool {
+        true
+    }
+
+    fn poll_events(&self) -> Vec<VREvent> {
+        match &self.display {
+            None => vec![],
+            Some(display) => {
+                display.borrow_mut()
+                       .poll_events()
+                       .into_iter()
+                       .map(|e| VREvent::Display(e))
+                       .collect()
+            }
+        }
+    }
+}
+
+impl VRExternalService {
+    pub fn new(ptr: VRExternalShmemPtr) -> VRExternalService {
+        VRExternalService {
+            shmem: ptr.clone(),
+            display: None,
+        }
+    }
+}

--- a/rust-webvr/src/lib.rs
+++ b/rust-webvr/src/lib.rs
@@ -1,3 +1,4 @@
+extern crate libc;
 extern crate rust_webvr_api;
 #[cfg(all(feature = "googlevr", target_os= "android"))]
 extern crate gvr_sys;

--- a/rust-webvr/src/vr_manager.rs
+++ b/rust-webvr/src/vr_manager.rs
@@ -20,6 +20,9 @@ use api::OculusVRServiceCreator;
 #[cfg(feature = "mock")]
 use api::MockServiceCreator;
 
+#[cfg(feature = "vrexternal")]
+use api::{VRExternalServiceCreator, VRExternalShmemPtr};
+
 // Single entry point all the VRServices and displays
 pub struct VRServiceManager {
     initialized: bool,
@@ -63,6 +66,13 @@ impl VRServiceManager {
         for creator in &creators {
             self.register(creator.new_service());
         }
+    }
+
+    // Register VRExternal service.
+    #[cfg(feature = "vrexternal")]
+    pub fn register_vrexternal(&mut self, ptr: VRExternalShmemPtr) {
+        let creator = VRExternalServiceCreator::new(ptr);
+        self.register(creator.new_service());
     }
 
     // Register mock VR Service


### PR DESCRIPTION
This adds support for Firefox Reality. It's incomplete because:

1. the rendering part is not supported (submit frame doesn't work yet)
2. it's missing the servo glue (WIP here: https://github.com/servo/servo/compare/master...paulrouget:immersive)

I'd like to land that for 2 reasons:

1. get early feedback
2. being able to start landing stuff in servo, Firefox Reality, and Mozilla Central. rust-webvr is the first piece.