### PR TITLE
ATOMIC_USIZE_INIT is deprecated

### DIFF
--- a/rust-webvr-api/src/utils.rs
+++ b/rust-webvr-api/src/utils.rs
@@ -1,11 +1,11 @@
 #[cfg(feature = "utils")]
 
 use std::mem;
-use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
+use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
 use time;
 
-static DEVICE_ID_COUNTER: AtomicUsize  = ATOMIC_USIZE_INIT;
+static DEVICE_ID_COUNTER: AtomicUsize  = AtomicUsize::new(0);
 
 // Generates a unique identifier for any VRDisplay
 #[allow(dead_code)]


### PR DESCRIPTION
Get rid of the warning:
```
warning: use of deprecated item 'std::sync::atomic::ATOMIC_USIZE_INIT': the `new` function is now preferred
 --> /Users/ajeffrey/github/asajeffrey/rust-webvr/rust-webvr-api/src/utils.rs:8:42
  |
8 | static DEVICE_ID_COUNTER: AtomicUsize  = ATOMIC_USIZE_INIT;
  |                                          ^^^^^^^^^^^^^^^^^
```