### PR TITLE
Add flag for devices that expect the browser to present the VR content

### DIFF
--- a/rust-webvr-api/src/vr_display_capabilities.rs
+++ b/rust-webvr-api/src/vr_display_capabilities.rs
@@ -14,6 +14,9 @@ pub struct VRDisplayCapabilities {
     /// true if the VRDisplay is capable of presenting content to an HMD or similar device.
     pub can_present: bool,
 
+    /// true if the VR display expects the browser to present the content.
+    pub presented_by_browser: bool,
+
     /// Indicates the maximum length of the array that requestPresent() will accept,
     /// Must be 1 if canPresent is true, 0 otherwise.
     pub max_layers: u64
@@ -26,6 +29,7 @@ impl Default for VRDisplayCapabilities {
             has_orientation: false,
             has_external_display: false,
             can_present: false,
+            presented_by_browser: false,
             max_layers: 0
         }
     }


### PR DESCRIPTION
This is used by the browser to know if it should render the VR content itself, or if it should get out of the way and let the device do it. Used, e.g. in https://github.com/servo/servo/pull/22840, but will probably also be used by the magicleap implementation.