### PR TITLE
Add fetch_gamepads() support on VRDisplay

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,13 @@
 language: rust
-script: cargo build --features=googlevr,oculusvr
+
+rust:
+  - stable
+
+before_script:
+  - rustup target add armv7-linux-androideabi
+  - rustup target add x86_64-pc-windows-gnu
+  - sudo apt-get install libc6-dev-i386
+
+script:
+  - cargo check --target x86_64-pc-windows-gnu
+  - cd rust-webvr && cargo check --features "mock oculusvr googlevr" --no-default-features --target=armv7-linux-androideabi

--- a/rust-webvr-api/src/vr_display.rs
+++ b/rust-webvr-api/src/vr_display.rs
@@ -1,4 +1,4 @@
-use {VRDisplayData, VRFramebuffer, VRFramebufferAttributes, VRFrameData, VRFutureFrameData, VRLayer};
+use {VRDisplayData, VRFramebuffer, VRFramebufferAttributes, VRFrameData, VRFutureFrameData, VRGamepadPtr, VRLayer};
 use gleam::gl::Gl;
 use std::sync::Arc;
 use std::cell::RefCell;
@@ -12,6 +12,9 @@ pub trait VRDisplay: Send + Sync {
 
     /// Returns the current display data.
     fn data(&self) -> VRDisplayData;
+
+    /// Returns gamepads attached to this display
+    fn fetch_gamepads(&mut self) -> Result<Vec<VRGamepadPtr>, String>;
 
     /// Returns the immediate VRFrameData of the HMD
     /// Should be used when not presenting to the device.

--- a/rust-webvr/Cargo.toml
+++ b/rust-webvr/Cargo.toml
@@ -30,7 +30,6 @@ oculusvr = ["ovr-mobile-sys"]
 [dependencies]
 rust-webvr-api = { path = "../rust-webvr-api", version = "0.10.4" }
 log  = "0.4"
-libloading = { version = "0.5", optional = true, default-features = false }
 gvr-sys = { version = "0.7", optional = true }
 ovr-mobile-sys = { version = "0.4", optional = true }
 libc = "0.2"
@@ -38,6 +37,9 @@ euclid = { version = "0.19", optional = true }
 gleam = { version = "0.6", optional = true }
 glutin = { version = "0.19", optional = true }
 winit = { version = "0.18", optional = true }
+
+[target.'cfg(target_os="windows")'.dependencies]
+libloading = { version = "0.5", optional = true, default-features = false }
 
 [build-dependencies]
 gl_generator = "0.10"

--- a/rust-webvr/src/api/glwindow/display.rs
+++ b/rust-webvr/src/api/glwindow/display.rs
@@ -12,6 +12,7 @@ use rust_webvr_api::VRFrameData;
 use rust_webvr_api::VRFutureFrameData;
 use rust_webvr_api::VRFramebuffer;
 use rust_webvr_api::VRFramebufferAttributes;
+use rust_webvr_api::VRGamepadPtr;
 use rust_webvr_api::VRLayer;
 use rust_webvr_api::VRViewport;
 use std::cell::RefCell;
@@ -171,6 +172,10 @@ impl VRDisplay for GlWindowVRDisplay {
 
     fn stop_present(&mut self) {
         let _ = self.sender.send(GlWindowVRMessage::StopPresenting);
+    }
+
+    fn fetch_gamepads(&mut self) -> Result<Vec<VRGamepadPtr>, String> {
+        Ok(vec![])
     }
 }
 

--- a/rust-webvr/src/api/googlevr/display.rs
+++ b/rust-webvr/src/api/googlevr/display.rs
@@ -338,6 +338,10 @@ impl GoogleVRDisplay {
         let display_id = utils::new_id();
         let gamepad = GoogleVRGamepad::new(ctx, controller_ctx, display_id).ok();
 
+        if gamepad.is_none() {
+            warn!("No googlevr gamepad found");
+        }
+
         Arc::new(RefCell::new(GoogleVRDisplay {
             service: service,
             ctx: ctx,

--- a/rust-webvr/src/api/googlevr/display.rs
+++ b/rust-webvr/src/api/googlevr/display.rs
@@ -1,7 +1,8 @@
 #![cfg(feature = "googlevr")]
 use {VRDisplay, VRDisplayData, VRDisplayCapabilities, VRFramebuffer, VRFramebufferAttributes,
-    VREvent, VRDisplayEvent, VREyeParameters, VRFrameData, VRLayer, VRViewport};
+    VREvent, VRDisplayEvent, VREyeParameters, VRFrameData, VRLayer, VRViewport, VRGamepadPtr};
 use super::service::GoogleVRService;
+use super::gamepad::{GoogleVRGamepad, GoogleVRGamepadPtr};
 use rust_webvr_api::utils;
 #[cfg(target_os="android")]
 use rust_webvr_api::jni_utils::JNIScope;
@@ -26,6 +27,7 @@ const PREDICTION_OFFSET_NANOS: i64 = 50000000; // 50ms
 
 pub struct GoogleVRDisplay {
     service: *const GoogleVRService,
+    gamepad: Option<GoogleVRGamepadPtr>,
     ctx: *mut gvr::gvr_context,
     viewport_list: *mut gvr::gvr_buffer_viewport_list,
     left_eye_vp: *mut gvr::gvr_buffer_viewport,
@@ -76,6 +78,10 @@ impl VRDisplay for GoogleVRDisplay {
         data.stage_parameters = None;
 
         data
+    }
+
+    fn fetch_gamepads(&mut self) -> Result<Vec<VRGamepadPtr>,String> {
+        Ok(self.gamepad.clone().map(|d| d as VRGamepadPtr).into_iter().collect())
     }
 
     fn immediate_frame_data(&self, near: f64, far: f64) -> VRFrameData {
@@ -311,7 +317,8 @@ impl VRDisplay for GoogleVRDisplay {
 
 impl GoogleVRDisplay {
     pub unsafe fn new(service: *const GoogleVRService,
-                      ctx: *mut gvr::gvr_context) -> Arc<RefCell<GoogleVRDisplay>> {
+                      ctx: *mut gvr::gvr_context,
+                      controller_ctx: *mut gvr::gvr_controller_context) -> Arc<RefCell<GoogleVRDisplay>> {
         let list = gvr::gvr_buffer_viewport_list_create(ctx);
 
         // gvr_refresh_viewer_profile must be called before getting recommended bufer viewports.
@@ -327,6 +334,9 @@ impl GoogleVRDisplay {
         gvr::gvr_buffer_viewport_list_get_item(list, gvr::gvr_eye::GVR_LEFT_EYE as usize, left_eye_vp);
         let right_eye_vp = gvr::gvr_buffer_viewport_create(ctx);
         gvr::gvr_buffer_viewport_list_get_item(list, gvr::gvr_eye::GVR_RIGHT_EYE as usize, right_eye_vp);
+
+        let display_id = utils::new_id();
+        let gamepad = GoogleVRGamepad::new(ctx, controller_ctx, display_id).ok();
 
         Arc::new(RefCell::new(GoogleVRDisplay {
             service: service,
@@ -344,14 +354,19 @@ impl GoogleVRDisplay {
             synced_head_matrix: gvr_identity_matrix(),
             fbo_id: 0,
             fbo_texture: 0,
-            display_id: utils::new_id(),
+            display_id,
             presenting: false,
             paused: false,
             new_events_hint: false,
             pending_events: Mutex::new(Vec::new()),
             processed_events: Mutex::new(Vec::new()),
             attributes: Default::default(),
+            gamepad
         }))
+    }
+
+    pub fn gamepad(&self) -> Option<&GoogleVRGamepadPtr> {
+        self.gamepad.as_ref()
     }
 
     unsafe fn initialize_gl(&mut self) {
@@ -513,21 +528,27 @@ impl GoogleVRDisplay {
     // Warning: this function is called from java Main thread
     // Use mutexes to ensure thread safety and process the event in sync with the render loop.
     #[allow(dead_code)]
-    pub fn pause(&mut self) {
+    pub unsafe fn pause(&mut self) {
         let mut pending = self.pending_events.lock().unwrap();
         pending.push(VRDisplayEvent::Pause(self.display_id).into());
 
         self.new_events_hint = true;
+        if let Some(ref gamepad) = self.gamepad {
+            (*gamepad.as_ptr()).pause();
+        }
     }
 
     // Warning: this function is called from java Main thread
     // Use mutexes to ensure thread safety and process the event in sync with the render loop.
     #[allow(dead_code)]
-    pub fn resume(&mut self) {
+    pub unsafe fn resume(&mut self) {
         let mut pending = self.pending_events.lock().unwrap();
         pending.push(VRDisplayEvent::Resume(self.display_id).into());
 
         self.new_events_hint = true;
+        if let Some(ref gamepad) = self.gamepad {
+            (*gamepad.as_ptr()).resume();
+        }
     }
 
     fn handle_events(&mut self) {

--- a/rust-webvr/src/api/mock/display.rs
+++ b/rust-webvr/src/api/mock/display.rs
@@ -1,4 +1,4 @@
-use {VRDisplay, VRDisplayData, VRFramebuffer, VRFramebufferAttributes, VRFrameData, VRStageParameters, VRLayer, VRViewport};
+use {VRDisplay, VRDisplayData, VRFramebuffer, VRFramebufferAttributes, VRFrameData, VRGamepadPtr, VRStageParameters, VRLayer, VRViewport};
 use rust_webvr_api::utils;
 use std::sync::Arc;
 use std::cell::RefCell;
@@ -136,6 +136,10 @@ impl VRDisplay for MockVRDisplay {
 
     fn render_layer(&mut self, _layer: &VRLayer) {
         // No op
+    }
+
+    fn fetch_gamepads(&mut self) -> Result<Vec<VRGamepadPtr>,String> {
+        Ok(Vec::new())
     }
 
     fn submit_frame(&mut self) {

--- a/rust-webvr/src/api/oculusvr/display.rs
+++ b/rust-webvr/src/api/oculusvr/display.rs
@@ -2,7 +2,7 @@
 #![cfg(feature = "oculusvr")]
 
 use {VRDisplay, VRDisplayData, VRDisplayCapabilities, VREvent, VRDisplayEvent, 
-    VREyeParameters, VRFramebuffer, VRFramebufferAttributes, VRFrameData, VRLayer, VRViewport};
+    VREyeParameters, VRFramebuffer, VRFramebufferAttributes, VRFrameData, VRGamepadPtr, VRLayer, VRViewport};
 use android_injected_glue::ffi as ndk;
 use gl;
 use egl;
@@ -111,6 +111,10 @@ impl VRDisplay for OculusVRDisplay {
         }
 
         data
+    }
+
+    fn fetch_gamepads(&mut self) -> Result<Vec<VRGamepadPtr>,String> {
+        Ok(self.gamepads.iter().cloned().map(|g| g as VRGamepadPtr).collect())
     }
 
     fn reset_pose(&mut self) {
@@ -638,10 +642,6 @@ impl OculusVRDisplay {
         let mut events = self.events.lock().unwrap();
         out.extend(events.drain(..));
         self.new_events_hint = false;
-    }
-
-    pub fn fetch_gamepads(&self, out: &mut Vec<OculusVRGamepadPtr>) {
-        out.extend(self.gamepads.iter().cloned());
     }
 }
 

--- a/rust-webvr/src/api/vrexternal/android/display.rs
+++ b/rust-webvr/src/api/vrexternal/android/display.rs
@@ -5,7 +5,7 @@ use std::mem;
 use std::sync::Arc;
 use {
     VRDisplay, VRDisplayData, VRDisplayEvent, VRFrameData, VRFramebuffer,
-    VRFramebufferAttributes, VRLayer, VRViewport,
+    VRFramebufferAttributes, VRGamepadPtr, VRLayer, VRViewport,
 };
 
 pub type VRExternalDisplayPtr = Arc<RefCell<VRExternalDisplay>>;
@@ -239,6 +239,10 @@ impl VRDisplay for VRExternalDisplay {
 
         self.browser_state.layerState[0] = layer;
         self.push_browser();
+    }
+
+    fn fetch_gamepads(&mut self) -> Result<Vec<VRGamepadPtr>, String> {
+        Ok(Vec::new())
     }
 
     fn start_present(&mut self, attributes: Option<VRFramebufferAttributes>) {


### PR DESCRIPTION
WebXR considers gamepads to be attached to the display. I could pass around the VR service on the Servo side, however the safety invariants seem super tricky and I'd rather not complicate that.

This also cleans up the code on backends which don't support multiple displays or gamepads.


Eventually VR displays should have a way to subscribe to individual gamepads so that sync_poses calls can get all the updates they need at once.

r? @MortimerGoro