### PR TITLE
Basic mocking functionality

### DIFF
--- a/rust-webvr/src/api/mock/display.rs
+++ b/rust-webvr/src/api/mock/display.rs
@@ -1,15 +1,20 @@
 use {VRDisplay, VRDisplayData, VRFramebuffer, VRFramebufferAttributes, VRFrameData, VRGamepadPtr, VRStageParameters, VRLayer, VRViewport};
 use rust_webvr_api::utils;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::cell::RefCell;
 pub type MockVRDisplayPtr = Arc<RefCell<MockVRDisplay>>;
 use std::time::Duration;
 use std::thread;
+use super::MockVRControlMsg;
 
 pub struct MockVRDisplay {
     display_id: u32,
     attributes: VRFramebufferAttributes,
+    state: Arc<Mutex<MockVRState>>,
 }
+
+#[derive(Default)]
+pub struct MockVRState {}
 
 unsafe impl Send for MockVRDisplay {}
 unsafe impl Sync for MockVRDisplay {}
@@ -19,7 +24,12 @@ impl MockVRDisplay {
         Arc::new(RefCell::new(MockVRDisplay {
             display_id: utils::new_id(),
             attributes: Default::default(),
+            state: Default::default(),
         }))
+    }
+
+    pub fn state_handle(&self) -> Arc<Mutex<MockVRState>> {
+        self.state.clone()
     }
 }
 
@@ -153,3 +163,10 @@ impl VRDisplay for MockVRDisplay {
     }
 }
 
+impl MockVRState {
+    pub fn handle_msg(&mut self, msg: MockVRControlMsg) {
+        match msg {
+
+        }
+    }
+}

--- a/rust-webvr/src/api/mock/display.rs
+++ b/rust-webvr/src/api/mock/display.rs
@@ -13,18 +13,21 @@ pub struct MockVRDisplay {
     state: Arc<Mutex<MockVRState>>,
 }
 
-#[derive(Default)]
-pub struct MockVRState {}
+pub struct MockVRState {
+    display_data: VRDisplayData,
+    frame_data: VRFrameData,
+}
 
 unsafe impl Send for MockVRDisplay {}
 unsafe impl Sync for MockVRDisplay {}
 
 impl MockVRDisplay {
     pub fn new() -> MockVRDisplayPtr {
+        let display_id = utils::new_id();
         Arc::new(RefCell::new(MockVRDisplay {
-            display_id: utils::new_id(),
+            display_id,
             attributes: Default::default(),
-            state: Default::default(),
+            state: Arc::new(Mutex::new(MockVRState::new(display_id))),
         }))
     }
 
@@ -40,78 +43,11 @@ impl VRDisplay for MockVRDisplay {
     }
 
     fn data(&self) -> VRDisplayData {
-        let mut data = VRDisplayData::default();
-        
-        // Mock display data
-        // Simulates a virtual HTC Vive
-
-        data.display_name = "Mock VRDisplay".into();
-        data.display_id = self.display_id;
-        data.connected = true;
-
-        data.capabilities.can_present = true;
-        data.capabilities.has_orientation = true;
-        data.capabilities.has_external_display = true;
-        data.capabilities.has_position = true;
-
-        data.stage_parameters = Some(VRStageParameters {
-            sitting_to_standing_transform: [-0.9317312, 0.0, 0.36314875, 0.0, 0.0, 0.99999994, 0.0, 0.0, -0.36314875, 
-                                            0.0, -0.9317312, 0.0, 0.23767996, 1.6813644, 0.45370483, 1.0],
-            size_x: 2.0,
-            size_z: 2.0
-        });
-
-        data.left_eye_parameters.offset = [0.035949998, 0.0, 0.015];
-        data.left_eye_parameters.render_width = 1512;
-        data.left_eye_parameters.render_height = 1680;
-        data.left_eye_parameters.field_of_view.up_degrees = 55.82093048095703;
-        data.left_eye_parameters.field_of_view.right_degrees = 51.26948547363281;
-        data.left_eye_parameters.field_of_view.down_degrees = 55.707801818847656;
-        data.left_eye_parameters.field_of_view.left_degrees = 54.42263412475586;
-
-        data.right_eye_parameters.offset = [-0.035949998, 0.0, 0.015];
-        data.right_eye_parameters.render_width = 1512;
-        data.right_eye_parameters.render_height = 1680;
-        data.right_eye_parameters.field_of_view.up_degrees = 55.898048400878906;
-        data.right_eye_parameters.field_of_view.right_degrees = 54.37410354614258;
-        data.right_eye_parameters.field_of_view.down_degrees = 55.614715576171875;
-        data.right_eye_parameters.field_of_view.left_degrees = 51.304901123046875;
-        
-        data
+        self.state.lock().unwrap().display_data.clone()
     }
 
     fn immediate_frame_data(&self, _near_z: f64, _far_z: f64) -> VRFrameData {
-        let mut data = VRFrameData::default();
-        // Position vector
-        data.pose.position = Some([0.5, -0.7, -0.3]);
-        // Orientation quaternion
-        // TODO: Add animation
-        data.pose.orientation = Some([0.9385081, -0.08066622, -0.3347714, 0.024972256]);
-
-        // Simulates HTC Vive projections
-        data.left_projection_matrix = [0.75620246, 0.0, 0.0, 0.0,
-                                       0.0, 0.68050665, 0.0, 0.0,
-                                      -0.05713458, -0.0021225351, -1.0000999, -1.0, 
-                                       0.0, 0.0, -0.10000999, 0.0];
-
-        data.left_view_matrix = [1.0, 0.0, 0.0, 0.0, 
-                                 0.0, 1.0, 0.0, 0.0, 
-                                 0.0, 0.0, 1.0, 0.0, 
-                                -0.035949998, 0.0, 0.015, 1.0];
-
-        data.right_projection_matrix = [0.75646526, 0.0, 0.0, 0.0, 
-                                        0.0, 0.68069947, 0.0, 0.0, 
-                                        0.055611316, -0.005315368, -1.0000999, -1.0, 
-                                        0.0, 0.0, -0.10000999, 0.0];
-
-        data.right_view_matrix = [1.0, 0.0, 0.0, 0.0,
-                                  0.0, 1.0, 0.0, 0.0,
-                                  0.0, 0.0, 1.0, 0.0,
-                                  0.035949998, 0.0, 0.015, 1.0];
-
-        data.timestamp = utils::timestamp();
-
-        data
+        self.state.lock().unwrap().frame_data.clone()
     }
 
     fn synced_frame_data(&self, near_z: f64, far_z: f64) -> VRFrameData {
@@ -167,6 +103,83 @@ impl MockVRState {
     pub fn handle_msg(&mut self, msg: MockVRControlMsg) {
         match msg {
 
+        }
+    }
+}
+
+impl MockVRState {
+    pub fn new(display_id: u32) -> Self {
+        let mut display_data = VRDisplayData::default();
+        
+        // Mock display data
+        // Simulates a virtual HTC Vive
+
+        display_data.display_name = "Mock VRDisplay".into();
+        display_data.display_id = display_id;
+        display_data.connected = true;
+
+        display_data.capabilities.can_present = true;
+        display_data.capabilities.has_orientation = true;
+        display_data.capabilities.has_external_display = true;
+        display_data.capabilities.has_position = true;
+
+        display_data.stage_parameters = Some(VRStageParameters {
+            sitting_to_standing_transform: [-0.9317312, 0.0, 0.36314875, 0.0, 0.0, 0.99999994, 0.0, 0.0, -0.36314875, 
+                                            0.0, -0.9317312, 0.0, 0.23767996, 1.6813644, 0.45370483, 1.0],
+            size_x: 2.0,
+            size_z: 2.0
+        });
+
+        display_data.left_eye_parameters.offset = [0.035949998, 0.0, 0.015];
+        display_data.left_eye_parameters.render_width = 1512;
+        display_data.left_eye_parameters.render_height = 1680;
+        display_data.left_eye_parameters.field_of_view.up_degrees = 55.82093048095703;
+        display_data.left_eye_parameters.field_of_view.right_degrees = 51.26948547363281;
+        display_data.left_eye_parameters.field_of_view.down_degrees = 55.707801818847656;
+        display_data.left_eye_parameters.field_of_view.left_degrees = 54.42263412475586;
+
+        display_data.right_eye_parameters.offset = [-0.035949998, 0.0, 0.015];
+        display_data.right_eye_parameters.render_width = 1512;
+        display_data.right_eye_parameters.render_height = 1680;
+        display_data.right_eye_parameters.field_of_view.up_degrees = 55.898048400878906;
+        display_data.right_eye_parameters.field_of_view.right_degrees = 54.37410354614258;
+        display_data.right_eye_parameters.field_of_view.down_degrees = 55.614715576171875;
+        display_data.right_eye_parameters.field_of_view.left_degrees = 51.304901123046875;
+        
+
+        let mut frame_data = VRFrameData::default();
+        // Position vector
+        frame_data.pose.position = Some([0.5, -0.7, -0.3]);
+        // Orientation quaternion
+        // TODO: Add animation
+        frame_data.pose.orientation = Some([0.9385081, -0.08066622, -0.3347714, 0.024972256]);
+
+        // Simulates HTC Vive projections
+        frame_data.left_projection_matrix = [0.75620246, 0.0, 0.0, 0.0,
+                                       0.0, 0.68050665, 0.0, 0.0,
+                                      -0.05713458, -0.0021225351, -1.0000999, -1.0, 
+                                       0.0, 0.0, -0.10000999, 0.0];
+
+        frame_data.left_view_matrix = [1.0, 0.0, 0.0, 0.0, 
+                                 0.0, 1.0, 0.0, 0.0, 
+                                 0.0, 0.0, 1.0, 0.0, 
+                                -0.035949998, 0.0, 0.015, 1.0];
+
+        frame_data.right_projection_matrix = [0.75646526, 0.0, 0.0, 0.0, 
+                                        0.0, 0.68069947, 0.0, 0.0, 
+                                        0.055611316, -0.005315368, -1.0000999, -1.0, 
+                                        0.0, 0.0, -0.10000999, 0.0];
+
+        frame_data.right_view_matrix = [1.0, 0.0, 0.0, 0.0,
+                                  0.0, 1.0, 0.0, 0.0,
+                                  0.0, 0.0, 1.0, 0.0,
+                                  0.035949998, 0.0, 0.015, 1.0];
+
+        frame_data.timestamp = utils::timestamp();
+
+        Self {
+            display_data,
+            frame_data
         }
     }
 }

--- a/rust-webvr/src/api/mock/display.rs
+++ b/rust-webvr/src/api/mock/display.rs
@@ -102,7 +102,21 @@ impl VRDisplay for MockVRDisplay {
 impl MockVRState {
     pub fn handle_msg(&mut self, msg: MockVRControlMsg) {
         match msg {
-
+            MockVRControlMsg::SetViewerPose(position, orientation) => {
+                self.frame_data.pose.position = Some(position);
+                self.frame_data.pose.orientation = Some(orientation);
+            }
+            MockVRControlMsg::SetEyeParameters(left, right) => {
+                self.display_data.left_eye_parameters = left;
+                self.display_data.right_eye_parameters = right;
+            }
+            MockVRControlMsg::SetProjectionMatrices(left, right) => {
+                self.frame_data.left_projection_matrix = left;
+                self.frame_data.right_projection_matrix = right;
+            }
+            MockVRControlMsg::SetStageParameters(stage) => {
+                self.display_data.stage_parameters = Some(stage);
+            }
         }
     }
 }

--- a/rust-webvr/src/api/mock/mod.rs
+++ b/rust-webvr/src/api/mock/mod.rs
@@ -2,6 +2,7 @@ mod display;
 mod service;
 
 use {VRService, VRServiceCreator};
+use std::sync::mpsc::{channel, Sender};
 
 pub struct MockServiceCreator;
 
@@ -9,10 +10,20 @@ impl MockServiceCreator {
     pub fn new() -> Box<VRServiceCreator> {
         Box::new(MockServiceCreator)
     }
+
+    pub fn new_service_with_remote() -> (Box<VRService>, Sender<MockVRControlMsg>) {
+        let (send, rcv) = channel();
+        let service = service::MockVRService::new_with_receiver(rcv);
+        (Box::new(service), send)
+    }
 }
 
 impl VRServiceCreator for MockServiceCreator {
      fn new_service(&self) -> Box<VRService> {
          Box::new(service::MockVRService::new())
      }
+}
+
+pub enum MockVRControlMsg {
+
 }

--- a/rust-webvr/src/api/mock/mod.rs
+++ b/rust-webvr/src/api/mock/mod.rs
@@ -29,4 +29,6 @@ pub enum MockVRControlMsg {
     SetEyeParameters(VREyeParameters, VREyeParameters),
     SetProjectionMatrices([f32; 16], [f32; 16]),
     SetStageParameters(VRStageParameters),
+    Focus,
+    Blur,
 }

--- a/rust-webvr/src/api/mock/mod.rs
+++ b/rust-webvr/src/api/mock/mod.rs
@@ -1,7 +1,7 @@
 mod display;
 mod service;
 
-use {VRService, VRServiceCreator};
+use {VRService, VRServiceCreator, VREyeParameters, VRStageParameters};
 use std::sync::mpsc::{channel, Sender};
 
 pub struct MockServiceCreator;
@@ -25,5 +25,8 @@ impl VRServiceCreator for MockServiceCreator {
 }
 
 pub enum MockVRControlMsg {
-
+    SetViewerPose([f32; 3], [f32; 4]),
+    SetEyeParameters(VREyeParameters, VREyeParameters),
+    SetProjectionMatrices([f32; 16], [f32; 16]),
+    SetStageParameters(VRStageParameters),
 }

--- a/rust-webvr/src/api/mock/service.rs
+++ b/rust-webvr/src/api/mock/service.rs
@@ -28,8 +28,7 @@ impl VRService for MockVRService {
     }
 
     fn poll_events(&self) -> Vec<VREvent> {
-        // TODO: fake mock events
-        Vec::new()
+        self.display.borrow().poll_events()
     }
 }
 

--- a/rust-webvr/src/api/mock/service.rs
+++ b/rust-webvr/src/api/mock/service.rs
@@ -2,7 +2,7 @@ use {VRService, VRDisplayPtr, VREvent, VRGamepadPtr};
 use super::display::{MockVRDisplay, MockVRDisplayPtr};
 
 pub struct MockVRService {
-    displays: Vec<MockVRDisplayPtr>,
+    display: MockVRDisplayPtr,
 }
 
 unsafe impl Send for MockVRService {}
@@ -13,11 +13,7 @@ impl VRService for MockVRService {
     }
 
     fn fetch_displays(&mut self) -> Result<Vec<VRDisplayPtr>,String> {
-        if self.displays.len() == 0 {
-            self.displays.push(MockVRDisplay::new())
-        }
-
-        Ok(self.clone_displays())
+        Ok(vec![self.display.clone()])
     }
 
     fn fetch_gamepads(&mut self) -> Result<Vec<VRGamepadPtr>,String> {
@@ -37,10 +33,7 @@ impl VRService for MockVRService {
 impl MockVRService {
     pub fn new() -> MockVRService {
         MockVRService {
-            displays: Vec::new(),
+            display: MockVRDisplay::new(),
         }
-    }
-    fn clone_displays(&self) -> Vec<VRDisplayPtr> {
-        self.displays.iter().map(|d| d.clone() as VRDisplayPtr).collect()
     }
 }

--- a/rust-webvr/src/api/mod.rs
+++ b/rust-webvr/src/api/mod.rs
@@ -8,7 +8,7 @@ pub use self::vrexternal::VRExternalServiceCreator;
 #[cfg(feature = "mock")]
 mod mock;
 #[cfg(feature = "mock")]
-pub use self::mock::MockServiceCreator;
+pub use self::mock::{MockServiceCreator, MockVRControlMsg};
 
 #[cfg(feature = "glwindow")]
 mod glwindow;

--- a/rust-webvr/src/vr_manager.rs
+++ b/rust-webvr/src/vr_manager.rs
@@ -18,7 +18,7 @@ use api::OpenVRServiceCreator;
 use api::OculusVRServiceCreator;
 
 #[cfg(feature = "mock")]
-use api::MockServiceCreator;
+use api::{MockServiceCreator, MockVRControlMsg};
 
 #[cfg(feature = "vrexternal")]
 use api::VRExternalShmemPtr;
@@ -97,6 +97,14 @@ impl VRServiceManager {
         self.register(creator.new_service());
     }
 
+    // Register mock VR Service
+    // Usefull for testing
+    #[cfg(feature = "mock")]
+    pub fn register_mock_with_remote(&mut self) -> std::sync::mpsc::Sender<MockVRControlMsg> {
+        let (service, remote) = MockServiceCreator::new_service_with_remote();
+        self.register(service);
+        remote
+    }
 
     // Register a new VR service
     pub fn register(&mut self, service: Box<VRService>) {


### PR DESCRIPTION
Adds simple mocking functionality to the `mock` backend. This doesn't yet handle input sources.

Also, this is specifically designed to mock portions of the API WebXR uses. Attempting to access the view matrix whilst mocking will not produce anything useful, since WebXR doesn't use the view matrix.


This intends to roughly match the API capabilities given in https://github.com/immersive-web/webxr-test-api/blob/master/explainer.md

r? @MortimerGoro @asajeffrey