### PR TITLE
Mock API v2

### DIFF
--- a/rust-webvr-api/Cargo.toml
+++ b/rust-webvr-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-webvr-api"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["The Servo Project Developers"]
 
 homepage = "https://github.com/servo/rust-webvr"

--- a/rust-webvr-api/src/lib.rs
+++ b/rust-webvr-api/src/lib.rs
@@ -42,7 +42,7 @@ pub mod vr_field_view;
 pub mod vr_gamepad;
 pub mod vr_main_thread_heartbeat;
 
-pub use mock::MockVRControlMsg;
+pub use mock::*;
 pub use vr_display::{VRDisplay,VRDisplayPtr};
 pub use vr_service::{VRService,VRServiceCreator};
 pub use vr_display_data::VRDisplayData;

--- a/rust-webvr-api/src/lib.rs
+++ b/rust-webvr-api/src/lib.rs
@@ -42,7 +42,7 @@ pub mod vr_field_view;
 pub mod vr_gamepad;
 pub mod vr_main_thread_heartbeat;
 
-pub use mock::*;
+pub use mock::{MockVRControlMsg, MockVRInit, MockVRView};
 pub use vr_display::{VRDisplay,VRDisplayPtr};
 pub use vr_service::{VRService,VRServiceCreator};
 pub use vr_display_data::VRDisplayData;

--- a/rust-webvr-api/src/mock.rs
+++ b/rust-webvr-api/src/mock.rs
@@ -1,4 +1,3 @@
-use crate::VRStageParameters;
 
 #[cfg_attr(feature = "serde-serialization", derive(Deserialize, Serialize))]
 #[derive(Debug)]

--- a/rust-webvr-api/src/mock.rs
+++ b/rust-webvr-api/src/mock.rs
@@ -1,12 +1,26 @@
-use crate::{VREyeParameters, VRStageParameters};
+use crate::VRStageParameters;
 
 #[cfg_attr(feature = "serde-serialization", derive(Deserialize, Serialize))]
 #[derive(Debug)]
 pub enum MockVRControlMsg {
     SetViewerPose([f32; 3], [f32; 4]),
-    SetEyeParameters(VREyeParameters, VREyeParameters),
-    SetProjectionMatrices([f32; 16], [f32; 16]),
-    SetStageParameters(VRStageParameters),
+    SetViews(MockVRView, MockVRView),
+    SetEyeLevel(f32),
     Focus,
     Blur,
+}
+
+#[cfg_attr(feature = "serde-serialization", derive(Deserialize, Serialize))]
+#[derive(Debug, Default)]
+pub struct MockVRInit {
+    pub views: Option<(MockVRView, MockVRView)>,
+    pub eye_level: Option<f32>,
+    pub viewer_origin: Option<([f32; 3], [f32; 4])>,
+}
+
+#[cfg_attr(feature = "serde-serialization", derive(Deserialize, Serialize))]
+#[derive(Debug)]
+pub struct MockVRView {
+    pub projection: [f32; 16],
+    pub offset: [f32; 3],
 }

--- a/rust-webvr/Cargo.toml
+++ b/rust-webvr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-webvr"
-version = "0.12.2"
+version = "0.13.0"
 authors = ["The Servo Project Developers"]
 
 homepage = "https://github.com/servo/rust-webvr"
@@ -29,7 +29,7 @@ oculusvr = ["ovr-mobile-sys"]
 magicleap = ["euclid", "gleam"]
 
 [dependencies]
-rust-webvr-api = { path = "../rust-webvr-api", version = "0.12.0" }
+rust-webvr-api = { path = "../rust-webvr-api", version = "0.13.0" }
 log  = "0.4"
 gvr-sys = { version = "0.7", optional = true }
 ovr-mobile-sys = { version = "0.4", optional = true }

--- a/rust-webvr/src/api/mock/display.rs
+++ b/rust-webvr/src/api/mock/display.rs
@@ -134,7 +134,7 @@ impl MockVRState {
 }
 
 impl MockVRState {
-    pub fn new(display_id: u32, _init: MockVRInit) -> Self {
+    pub fn new(display_id: u32, init: MockVRInit) -> Self {
         let mut display_data = VRDisplayData::default();
         
         // Mock display data
@@ -149,6 +149,7 @@ impl MockVRState {
         display_data.capabilities.has_external_display = true;
         display_data.capabilities.has_position = true;
 
+        // todo use init.eye_level
         display_data.stage_parameters = Some(VRStageParameters {
             sitting_to_standing_transform: [-0.9317312, 0.0, 0.36314875, 0.0, 0.0, 0.99999994, 0.0, 0.0, -0.36314875, 
                                             0.0, -0.9317312, 0.0, 0.23767996, 1.6813644, 0.45370483, 1.0],
@@ -156,7 +157,6 @@ impl MockVRState {
             size_z: 2.0
         });
 
-        display_data.left_eye_parameters.offset = [0.035949998, 0.0, 0.015];
         display_data.left_eye_parameters.render_width = 1512;
         display_data.left_eye_parameters.render_height = 1680;
         display_data.left_eye_parameters.field_of_view.up_degrees = 55.82093048095703;
@@ -164,7 +164,6 @@ impl MockVRState {
         display_data.left_eye_parameters.field_of_view.down_degrees = 55.707801818847656;
         display_data.left_eye_parameters.field_of_view.left_degrees = 54.42263412475586;
 
-        display_data.right_eye_parameters.offset = [-0.035949998, 0.0, 0.015];
         display_data.right_eye_parameters.render_width = 1512;
         display_data.right_eye_parameters.render_height = 1680;
         display_data.right_eye_parameters.field_of_view.up_degrees = 55.898048400878906;
@@ -174,32 +173,48 @@ impl MockVRState {
         
 
         let mut frame_data = VRFrameData::default();
-        // Position vector
-        frame_data.pose.position = Some([0.5, -0.7, -0.3]);
-        // Orientation quaternion
-        // TODO: Add animation
-        frame_data.pose.orientation = Some([0.9385081, -0.08066622, -0.3347714, 0.024972256]);
 
-        // Simulates HTC Vive projections
-        frame_data.left_projection_matrix = [0.75620246, 0.0, 0.0, 0.0,
-                                       0.0, 0.68050665, 0.0, 0.0,
-                                      -0.05713458, -0.0021225351, -1.0000999, -1.0, 
-                                       0.0, 0.0, -0.10000999, 0.0];
+        if let Some((position, orientation)) = init.viewer_origin {
+            frame_data.pose.position = Some(position);
+            frame_data.pose.orientation = Some(orientation);
+        } else {
+            // Position vector
+            frame_data.pose.position = Some([0.5, -0.7, -0.3]);
+            // Orientation quaternion
+            // TODO: Add animation
+            frame_data.pose.orientation = Some([0.9385081, -0.08066622, -0.3347714, 0.024972256]);
+        }
 
-        frame_data.left_view_matrix = [1.0, 0.0, 0.0, 0.0, 
-                                 0.0, 1.0, 0.0, 0.0, 
-                                 0.0, 0.0, 1.0, 0.0, 
-                                -0.035949998, 0.0, 0.015, 1.0];
+        if let Some((left, right)) = init.views {
+            display_data.left_eye_parameters.offset = left.offset;
+            display_data.right_eye_parameters.offset = right.offset;
+            frame_data.left_projection_matrix = left.projection;
+            frame_data.right_projection_matrix = right.projection;
+        } else {
+            display_data.left_eye_parameters.offset = [0.035949998, 0.0, 0.015];
+            display_data.right_eye_parameters.offset = [-0.035949998, 0.0, 0.015];
+            // Simulates HTC Vive projections
+            frame_data.left_projection_matrix = [0.75620246, 0.0, 0.0, 0.0,
+                                           0.0, 0.68050665, 0.0, 0.0,
+                                          -0.05713458, -0.0021225351, -1.0000999, -1.0, 
+                                           0.0, 0.0, -0.10000999, 0.0];
 
-        frame_data.right_projection_matrix = [0.75646526, 0.0, 0.0, 0.0, 
-                                        0.0, 0.68069947, 0.0, 0.0, 
-                                        0.055611316, -0.005315368, -1.0000999, -1.0, 
-                                        0.0, 0.0, -0.10000999, 0.0];
+            frame_data.left_view_matrix = [1.0, 0.0, 0.0, 0.0, 
+                                     0.0, 1.0, 0.0, 0.0, 
+                                     0.0, 0.0, 1.0, 0.0, 
+                                    -0.035949998, 0.0, 0.015, 1.0];
 
-        frame_data.right_view_matrix = [1.0, 0.0, 0.0, 0.0,
-                                  0.0, 1.0, 0.0, 0.0,
-                                  0.0, 0.0, 1.0, 0.0,
-                                  0.035949998, 0.0, 0.015, 1.0];
+            frame_data.right_projection_matrix = [0.75646526, 0.0, 0.0, 0.0, 
+                                            0.0, 0.68069947, 0.0, 0.0, 
+                                            0.055611316, -0.005315368, -1.0000999, -1.0, 
+                                            0.0, 0.0, -0.10000999, 0.0];
+
+            frame_data.right_view_matrix = [1.0, 0.0, 0.0, 0.0,
+                                      0.0, 1.0, 0.0, 0.0,
+                                      0.0, 0.0, 1.0, 0.0,
+                                      0.035949998, 0.0, 0.015, 1.0];
+        };
+
 
         frame_data.timestamp = utils::timestamp();
 

--- a/rust-webvr/src/api/mock/display.rs
+++ b/rust-webvr/src/api/mock/display.rs
@@ -113,18 +113,15 @@ impl MockVRState {
                 self.frame_data.pose.position = Some(position);
                 self.frame_data.pose.orientation = Some(orientation);
             }
-            MockVRControlMsg::SetEyeParameters(left, right) => {
-                self.display_data.left_eye_parameters = left;
-                self.display_data.right_eye_parameters = right;
+            MockVRControlMsg::SetViews(left, right) => {
+                self.display_data.left_eye_parameters.offset = left.offset;
+                self.display_data.right_eye_parameters.offset = right.offset;
+                self.frame_data.left_projection_matrix = left.projection;
+                self.frame_data.right_projection_matrix = right.projection;
                 self.events.push(VREvent::Display(VRDisplayEvent::Change(self.display_data.clone())))
             }
-            MockVRControlMsg::SetProjectionMatrices(left, right) => {
-                self.frame_data.left_projection_matrix = left;
-                self.frame_data.right_projection_matrix = right;
-            }
-            MockVRControlMsg::SetStageParameters(stage) => {
-                self.display_data.stage_parameters = Some(stage);
-                self.events.push(VREvent::Display(VRDisplayEvent::Change(self.display_data.clone())))
+            MockVRControlMsg::SetEyeLevel(_eye) => {
+                // do nothing for now
             }
             MockVRControlMsg::Focus => {
                 self.events.push(VREvent::Display(VRDisplayEvent::Focus(self.display_data.clone())))

--- a/rust-webvr/src/api/mock/display.rs
+++ b/rust-webvr/src/api/mock/display.rs
@@ -6,7 +6,7 @@ use std::mem;
 pub type MockVRDisplayPtr = Arc<RefCell<MockVRDisplay>>;
 use std::time::Duration;
 use std::thread;
-use super::MockVRControlMsg;
+use super::{MockVRControlMsg, MockVRInit};
 
 pub struct MockVRDisplay {
     display_id: u32,
@@ -24,12 +24,12 @@ unsafe impl Send for MockVRDisplay {}
 unsafe impl Sync for MockVRDisplay {}
 
 impl MockVRDisplay {
-    pub fn new() -> MockVRDisplayPtr {
+    pub fn new(init: MockVRInit) -> MockVRDisplayPtr {
         let display_id = utils::new_id();
         Arc::new(RefCell::new(MockVRDisplay {
             display_id,
             attributes: Default::default(),
-            state: Arc::new(Mutex::new(MockVRState::new(display_id))),
+            state: Arc::new(Mutex::new(MockVRState::new(display_id, init))),
         }))
     }
 
@@ -134,7 +134,7 @@ impl MockVRState {
 }
 
 impl MockVRState {
-    pub fn new(display_id: u32) -> Self {
+    pub fn new(display_id: u32, _init: MockVRInit) -> Self {
         let mut display_data = VRDisplayData::default();
         
         // Mock display data

--- a/rust-webvr/src/api/mock/mod.rs
+++ b/rust-webvr/src/api/mock/mod.rs
@@ -1,7 +1,7 @@
 mod display;
 mod service;
 
-pub use {VRService, VRServiceCreator, VREyeParameters, VRStageParameters, MockVRControlMsg};
+pub use {VRService, VRServiceCreator, VREyeParameters, VRStageParameters, MockVRControlMsg, MockVRInit, MockVRView};
 use std::sync::mpsc::{channel, Sender};
 
 pub struct MockServiceCreator;
@@ -11,15 +11,15 @@ impl MockServiceCreator {
         Box::new(MockServiceCreator)
     }
 
-    pub fn new_service_with_remote() -> (Box<VRService>, Sender<MockVRControlMsg>) {
+    pub fn new_service_with_remote(init: MockVRInit) -> (Box<VRService>, Sender<MockVRControlMsg>) {
         let (send, rcv) = channel();
-        let service = service::MockVRService::new_with_receiver(rcv);
+        let service = service::MockVRService::new_with_receiver(rcv, init);
         (Box::new(service), send)
     }
 }
 
 impl VRServiceCreator for MockServiceCreator {
      fn new_service(&self) -> Box<VRService> {
-         Box::new(service::MockVRService::new())
+         Box::new(service::MockVRService::new(Default::default()))
      }
 }

--- a/rust-webvr/src/api/mock/service.rs
+++ b/rust-webvr/src/api/mock/service.rs
@@ -1,6 +1,6 @@
 use {VRService, VRDisplayPtr, VREvent, VRGamepadPtr};
 use super::display::{MockVRDisplay, MockVRDisplayPtr};
-use super::MockVRControlMsg;
+use super::{MockVRControlMsg, MockVRInit};
 use std::thread;
 use std::sync::mpsc::Receiver;
 
@@ -33,14 +33,14 @@ impl VRService for MockVRService {
 }
 
 impl MockVRService {
-    pub fn new() -> MockVRService {
+    pub fn new(init: MockVRInit) -> MockVRService {
         MockVRService {
-            display: MockVRDisplay::new(),
+            display: MockVRDisplay::new(init),
         }
     }
 
-    pub fn new_with_receiver(rcv: Receiver<MockVRControlMsg>) -> MockVRService {
-        let display = MockVRDisplay::new();
+    pub fn new_with_receiver(rcv: Receiver<MockVRControlMsg>, init: MockVRInit) -> MockVRService {
+        let display = MockVRDisplay::new(init);
         let state = display.borrow().state_handle();
         thread::spawn(move || {
             while let Ok(msg) = rcv.recv() {

--- a/rust-webvr/src/api/mod.rs
+++ b/rust-webvr/src/api/mod.rs
@@ -8,7 +8,7 @@ pub use self::vrexternal::VRExternalServiceCreator;
 #[cfg(feature = "mock")]
 mod mock;
 #[cfg(feature = "mock")]
-pub use self::mock::{MockServiceCreator, MockVRControlMsg};
+pub use self::mock::{MockServiceCreator, MockVRControlMsg, MockVRInit};
 
 #[cfg(feature = "glwindow")]
 mod glwindow;

--- a/rust-webvr/src/vr_manager.rs
+++ b/rust-webvr/src/vr_manager.rs
@@ -18,7 +18,7 @@ use api::OpenVRServiceCreator;
 use api::OculusVRServiceCreator;
 
 #[cfg(feature = "mock")]
-use api::{MockServiceCreator, MockVRControlMsg};
+use api::{MockServiceCreator, MockVRControlMsg, MockVRInit};
 
 #[cfg(feature = "vrexternal")]
 use api::VRExternalShmemPtr;
@@ -100,8 +100,8 @@ impl VRServiceManager {
     // Register mock VR Service
     // Usefull for testing
     #[cfg(feature = "mock")]
-    pub fn register_mock_with_remote(&mut self) -> std::sync::mpsc::Sender<MockVRControlMsg> {
-        let (service, remote) = MockServiceCreator::new_service_with_remote();
+    pub fn register_mock_with_remote(&mut self, init: MockVRInit) -> std::sync::mpsc::Sender<MockVRControlMsg> {
+        let (service, remote) = MockServiceCreator::new_service_with_remote(init);
         self.register(service);
         remote
     }


### PR DESCRIPTION
This is a breaking change. Don't land yet, I want to test it on servo first. Plus, webvr updates are blocked by https://github.com/servo/servo/pull/23575

There are some stubs left over because I don't want to polish the backend too much if we're going to be moving to rust-webxr anyway; so i'm just implementing the functionality necessary for testing.


r? @asajeffrey