### PR TITLE
Fix oculus backend borrow error

### DIFF
--- a/rust-webvr/src/api/oculusvr/service.rs
+++ b/rust-webvr/src/api/oculusvr/service.rs
@@ -279,9 +279,9 @@ impl OVRJava {
                 let env = jni_scope.env;
 
                 // Initialize native VrApi
-                self.java.Vm = mem::transmute(&mut (*jni_scope.vm).functions);
-                self.java.Env = mem::transmute(&mut (*env).functions);
                 self.java.ActivityObject = (jni.NewGlobalRef)(env, jni_scope.activity) as *mut _;
+                self.java.Env = mem::transmute(&mut (*env).functions);
+                self.java.Vm = mem::transmute(&mut (*jni_scope.vm).functions);
             }
             self.jni_scope = Some(jni_scope);
 


### PR DESCRIPTION
From a previous PR's CI:
```
error[E0502]: cannot borrow `jni_scope.vm.functions` as mutable because it is also borrowed as immutable
   --> rust-webvr/src/api/oculusvr/service.rs:282:47
    |
278 |                 let jni = jni_scope.jni();
    |                           --------- immutable borrow occurs here
...
282 |                 self.java.Vm = mem::transmute(&mut (*jni_scope.vm).functions);
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
283 |                 self.java.Env = mem::transmute(&mut (*env).functions);
284 |                 self.java.ActivityObject = (jni.NewGlobalRef)(env, jni_scope.activity) as *mut _;
    |                                            ------------------ immutable borrow later used here
error: aborting due to previous error
```
This uses the power of NLL to avoid the problem.